### PR TITLE
Update SHA256 hash

### DIFF
--- a/kuri.rb
+++ b/kuri.rb
@@ -6,7 +6,7 @@ class Kuri < Formula
   desc ""
   homepage ""
   url "https://github.com/bannzai/Kuri/releases/download/0.1.2/kuri.zip"
-  sha256 "6fd315859b786c3907ada6956dbf7f7286df424c75c4123530e1aa6f2b892377"
+  sha256 "80ee883bce89b1257d6301d96ea1fb99b3f620f4e6951f93f6e83d6f70835513"
 
   # depends_on "cmake" => :build
 


### PR DESCRIPTION
Now `brew upgrade kuri` is failed :cry:

```
 ✘  ~  brew tap bannzai/homebrew-Kuri
 ~  brew upgrade kuri
==> Upgrading 1 outdated package, with result:
bannzai/kuri/kuri 0.1.2
==> Upgrading bannzai/kuri/kuri 
==> Downloading https://github.com/bannzai/Kuri/releases/download/0.1.2/kuri.zip
Already downloaded: /Users/dataich/Library/Caches/Homebrew/kuri-0.1.2.zip
Error: SHA256 mismatch
Expected: 6fd315859b786c3907ada6956dbf7f7286df424c75c4123530e1aa6f2b892377
Actual: 80ee883bce89b1257d6301d96ea1fb99b3f620f4e6951f93f6e83d6f70835513
Archive: /Users/dataich/Library/Caches/Homebrew/kuri-0.1.2.zip
To retry an incomplete download, remove the file above.
```